### PR TITLE
Gradual puking

### DIFF
--- a/PukingPredator/Assets/Prefabs/Player.prefab
+++ b/PukingPredator/Assets/Prefabs/Player.prefab
@@ -314,7 +314,7 @@ PrefabInstance:
     - target: {fileID: 8392385826554375232, guid: c98f49f8c63534cd0ab393f2d59e152a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.114
       objectReference: {fileID: 0}
     - target: {fileID: 8392385826554375232, guid: c98f49f8c63534cd0ab393f2d59e152a,
         type: 3}

--- a/PukingPredator/Assets/Scripts/Consumable/Consumable.cs
+++ b/PukingPredator/Assets/Scripts/Consumable/Consumable.cs
@@ -52,6 +52,11 @@ public class Consumable : MonoBehaviour
     private Collider hitbox;
 
     /// <summary>
+    /// The layer that the object started out on.
+    /// </summary>
+    private int initialLayer;
+
+    /// <summary>
     /// The initial scale of the instance before being eaten. Used to restore
     /// its size to normal after being puked.
     /// </summary>
@@ -127,6 +132,7 @@ public class Consumable : MonoBehaviour
 
     protected virtual void Awake()
     {
+        initialLayer = gameObject.layer;
         initialScale = gameObject.transform.localScale;
         rb = GetComponent<Rigidbody>();
         hitbox = GetComponent<Collider>();
@@ -140,7 +146,7 @@ public class Consumable : MonoBehaviour
         }
 
         if (rb != null) { stateEvents[ItemState.inWorld].onEnter += ResetVelocity; }
-        stateEvents[ItemState.inWorld].onEnter += SetLayerToConsumable;
+        stateEvents[ItemState.inWorld].onEnter += ResetLayer;
         stateEvents[ItemState.inWorld].onEnter += SetGravityEnabled;
         //stateEvents[ItemState.inWorld].onUpdate += UpdateProximityOutline;
         stateEvents[ItemState.inWorld].onExit += SetLayerToConsumed;
@@ -284,9 +290,9 @@ public class Consumable : MonoBehaviour
         }
     }
 
-    private void SetLayerToConsumable()
+    private void ResetLayer()
     {
-        SetLayer(GameLayer.consumable);
+        SetLayer(initialLayer);
     }
 
     private void SetLayerToConsumed()

--- a/PukingPredator/Assets/Scripts/Consumable/Consumable.cs
+++ b/PukingPredator/Assets/Scripts/Consumable/Consumable.cs
@@ -69,6 +69,17 @@ public class Consumable : MonoBehaviour
     public Inventory inventory;
 
     /// <summary>
+    /// The position that this object should be in if its in an inventory.
+    /// </summary>
+    private Vector3 inventoryTargetPosition
+    {
+        get
+        {
+            return inventory.transform.position;
+        }
+    }
+
+    /// <summary>
     /// Can be used to lock an item.
     /// </summary>
     public bool isConsumable = true;
@@ -164,7 +175,7 @@ public class Consumable : MonoBehaviour
         stateEvents[ItemState.inInventory].onEnter += ClampShrunkScale;
         stateEvents[ItemState.inInventory].onEnter += StartDecay;
         //stateEvents[ItemState.inInventory].onExit += EnablePhysics;
-        stateEvents[ItemState.inInventory].onUpdate += FollowOwner;
+        stateEvents[ItemState.inInventory].onUpdate += FollowInventory;
 
         if (rb != null) { stateEvents[ItemState.beingPuked].onEnter += ResetVelocity; }
         stateEvents[ItemState.beingPuked].onUpdate += UpdateBeingPuked;
@@ -227,10 +238,10 @@ public class Consumable : MonoBehaviour
         hitbox.enabled = true;
     }
 
-    private void FollowOwner()
+    private void FollowInventory()
     {
         //TODO: add some periodic + random offset so objects float around in you?
-        gameObject.transform.position = ownerTransform.position;
+        gameObject.transform.position = inventoryTargetPosition;
     }
 
     #region Gravity
@@ -347,9 +358,8 @@ public class Consumable : MonoBehaviour
 
     private void UpdateBeingConsumed()
     {
-        var ownerPosition = ownerTransform.position;
         var currRate = consumptionRate * Time.deltaTime;
-        gameObject.transform.position = Vector3.Lerp(gameObject.transform.position, ownerPosition, currRate);
+        gameObject.transform.position = Vector3.Lerp(gameObject.transform.position, inventoryTargetPosition, currRate);
         gameObject.transform.localScale = Vector3.Lerp(gameObject.transform.localScale, Vector3.zero, currRate);
 
         var hasBeenConsumed = gameObject.transform.localScale.magnitude / initialScale.magnitude < consumptionCutoff;

--- a/PukingPredator/Assets/Scripts/Consumable/Consumable.cs
+++ b/PukingPredator/Assets/Scripts/Consumable/Consumable.cs
@@ -151,6 +151,7 @@ public class Consumable : MonoBehaviour
         //stateEvents[ItemState.inWorld].onUpdate += UpdateProximityOutline;
         stateEvents[ItemState.inWorld].onExit += SetLayerToConsumed;
         stateEvents[ItemState.inWorld].onExit += SetGravityDisabled; 
+        stateEvents[ItemState.inWorld].onExit += DisableKinematic;
 
         stateEvents[ItemState.beingConsumed].onUpdate += UpdateBeingConsumed;
 
@@ -220,11 +221,6 @@ public class Consumable : MonoBehaviour
         hitbox.enabled = true;
     }
 
-    public void SetRBKinematic(bool isKinematic)
-    {
-        rb.isKinematic = isKinematic;
-    }
-
     private void FollowOwner()
     {
         //TODO: add some periodic + random offset so objects float around in you?
@@ -251,6 +247,18 @@ public class Consumable : MonoBehaviour
     private void SetGravityEnabled()
     {
         SetGravity(true);
+    }
+    #endregion
+
+    #region Kinematic
+    public void SetRBKinematic(bool isKinematic)
+    {
+        rb.isKinematic = isKinematic;
+    }
+
+    public void DisableKinematic()
+    {
+        SetRBKinematic(false);
     }
     #endregion
 
@@ -330,7 +338,6 @@ public class Consumable : MonoBehaviour
 
     private void UpdateBeingConsumed()
     {
-        SetRBKinematic(false);
         var ownerPosition = ownerTransform.position;
         var currRate = consumptionRate * Time.deltaTime;
         gameObject.transform.position = Vector3.Lerp(gameObject.transform.position, ownerPosition, currRate);

--- a/PukingPredator/Assets/Scripts/Eating.cs
+++ b/PukingPredator/Assets/Scripts/Eating.cs
@@ -45,11 +45,6 @@ public class Eating : InputBehaviour
     private Player player;
 
     /// <summary>
-    /// The distance that items spawn ahead of the player when puking. (TEMP)
-    /// </summary>
-    private float pukeDistance = 0.4f;
-
-    /// <summary>
     /// Force applied to object when puked. Depends on how long the puke button
     /// was held down for.
     /// </summary>
@@ -145,15 +140,13 @@ public class Eating : InputBehaviour
     {
         if (inventory.isEmpty) { return; }
 
-        Consumable itemToPlace = inventory.PopItem();
+        Consumable itemToPuke = inventory.PopItem();
+        itemToPuke.SetState(ItemState.beingPuked);
 
         //puke forward and with a little force upwards
-        var pukeDir = transform.forward + Vector3.up * 0.2f;
+        var pukeDir = transform.forward + Vector3.up * 0.1f;
 
-        var targetPosition = transform.position + pukeDir * pukeDistance;
-        itemToPlace.PlaceAt(targetPosition);
-
-        Rigidbody itemRb = itemToPlace.GetComponent<Rigidbody>();
+        Rigidbody itemRb = itemToPuke.GetComponent<Rigidbody>();
         if (itemRb != null)
         {
             //TODO: make this code work if there is no rigid body. perhaps just set

--- a/PukingPredator/Assets/Scripts/Eating.cs
+++ b/PukingPredator/Assets/Scripts/Eating.cs
@@ -55,7 +55,7 @@ public class Eating : InputBehaviour
             return Mathf.Lerp(MIN_PUKE_FORCE, MAX_PUKE_FORCE, holdPercent);
         }
     }
-    private const float MIN_PUKE_FORCE = 4f;
+    private const float MIN_PUKE_FORCE = 1f;
     private const float MAX_PUKE_FORCE = 20f;
     private const float MAX_PUKE_DURATION = 2f;
 


### PR DESCRIPTION
-Made it so objects get puked out gradually from inside the stomach instead of instantly spawning a fixed distance away
-Objects in your inventory now float in the middle(ish) of the character, defined by the inventory instance position instead of the player itself
-Objects now set the layer back to the original layer when being puked instead of an arbitrary constant layer