### PR TITLE
bridge in level1 middle pieces collapse by weight

### DIFF
--- a/PukingPredator/Assets/Scenes/PlayableLevelRemake.unity
+++ b/PukingPredator/Assets/Scenes/PlayableLevelRemake.unity
@@ -8478,6 +8478,25 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1176196208}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1179356054 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8987541414976748394, guid: 913ae199a4aec864b9af698531402093,
+    type: 3}
+  m_PrefabInstance: {fileID: 8397108269819503455}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1179356055
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1179356054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2736d28d9039c6a43b83e46f15ea521c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  massThreshold: 4
 --- !u!4 &1183215654 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4565252056226141326, guid: 11afdb49601ac461eba4b18865799ec5,
@@ -14291,6 +14310,25 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 54b9a1d96fa034c4583e0b9f36e074f3, type: 3}
+--- !u!1 &1986274019 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3058788561271639466, guid: 913ae199a4aec864b9af698531402093,
+    type: 3}
+  m_PrefabInstance: {fileID: 8397108269819503455}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1986274020
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1986274019}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2736d28d9039c6a43b83e46f15ea521c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  massThreshold: 4
 --- !u!4 &1999248525 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5942933661254003072, guid: 54b9a1d96fa034c4583e0b9f36e074f3,
@@ -16053,6 +16091,46 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 2100592862}
     m_Modifications:
+    - target: {fileID: 3086385670972515734, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.017
+      objectReference: {fileID: 0}
+    - target: {fileID: 3086385670972515734, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9990614
+      objectReference: {fileID: 0}
+    - target: {fileID: 3086385670972515734, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.0010467261
+      objectReference: {fileID: 0}
+    - target: {fileID: 3086385670972515734, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.0029945378
+      objectReference: {fileID: 0}
+    - target: {fileID: 3086385670972515734, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.043200996
+      objectReference: {fileID: 0}
+    - target: {fileID: 3086385670972515734, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.135
+      objectReference: {fileID: 0}
+    - target: {fileID: 3086385670972515734, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.338
+      objectReference: {fileID: 0}
+    - target: {fileID: 3086385670972515734, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -4.952
+      objectReference: {fileID: 0}
     - target: {fileID: 4343084477260941075, guid: 913ae199a4aec864b9af698531402093,
         type: 3}
       propertyPath: m_Name
@@ -16113,10 +16191,53 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8943548369045754710, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9991345
+      objectReference: {fileID: 0}
+    - target: {fileID: 8943548369045754710, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00061228115
+      objectReference: {fileID: 0}
+    - target: {fileID: 8943548369045754710, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.03842607
+      objectReference: {fileID: 0}
+    - target: {fileID: 8943548369045754710, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.015920212
+      objectReference: {fileID: 0}
+    - target: {fileID: 8943548369045754710, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 8943548369045754710, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 4.403
+      objectReference: {fileID: 0}
+    - target: {fileID: 8943548369045754710, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -1.82
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8987541414976748394, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1179356055}
+    - targetCorrespondingSourceObject: {fileID: 3058788561271639466, guid: 913ae199a4aec864b9af698531402093,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1986274020}
   m_SourcePrefab: {fileID: 100100000, guid: 913ae199a4aec864b9af698531402093, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:


### PR DESCRIPTION
The middle bridge pieces will collapse if the player is a certain size when walking over them.
Due to the physics, they don't actually fall immediately, but it might be good to just add to cue the player. The pieces will start moving if the player is large enough, and walks over them.

Either approve the changes, or delete the branch. If it's not too good, we don't need to add it

![image](https://github.com/user-attachments/assets/1764c974-a58f-4660-b63a-5b7fc98a891c)
