### PR TITLE
Puking with force knocks things back

### DIFF
--- a/PukingPredator/Assets/Prefabs/Structures/LargerStructures/PillarWithTorch.prefab
+++ b/PukingPredator/Assets/Prefabs/Structures/LargerStructures/PillarWithTorch.prefab
@@ -180,46 +180,40 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 4081027579589914596, guid: 515b8fbccb9274059a250a572e4178bb,
+    - targetCorrespondingSourceObject: {fileID: 5828374754627683335, guid: 515b8fbccb9274059a250a572e4178bb,
         type: 3}
       insertIndex: -1
-      addedObject: {fileID: 84047422311397584}
-    - targetCorrespondingSourceObject: {fileID: 4081027579589914596, guid: 515b8fbccb9274059a250a572e4178bb,
+      addedObject: {fileID: 1196181565453335520}
+    - targetCorrespondingSourceObject: {fileID: 5828374754627683335, guid: 515b8fbccb9274059a250a572e4178bb,
         type: 3}
       insertIndex: -1
-      addedObject: {fileID: 8747604621110247707}
+      addedObject: {fileID: 2076812491011672195}
   m_SourcePrefab: {fileID: 100100000, guid: 515b8fbccb9274059a250a572e4178bb, type: 3}
---- !u!4 &2380776408053245292 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8346230885965490542, guid: 515b8fbccb9274059a250a572e4178bb,
-    type: 3}
-  m_PrefabInstance: {fileID: 5970070246805539842}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &7672809627041293286 stripped
+--- !u!1 &160854941954017285 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 4081027579589914596, guid: 515b8fbccb9274059a250a572e4178bb,
+  m_CorrespondingSourceObject: {fileID: 5828374754627683335, guid: 515b8fbccb9274059a250a572e4178bb,
     type: 3}
   m_PrefabInstance: {fileID: 5970070246805539842}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &84047422311397584
+--- !u!114 &1196181565453335520
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7672809627041293286}
+  m_GameObject: {fileID: 160854941954017285}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a2531af01babb6e4993f0f50c35db1ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &8747604621110247707
+--- !u!114 &2076812491011672195
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7672809627041293286}
+  m_GameObject: {fileID: 160854941954017285}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 474c51a6229edf642af67e82b3b55636, type: 3}
@@ -229,6 +223,12 @@ MonoBehaviour:
   - {fileID: 193648101382873193}
   initiallySupporting: []
   supportsBeforeCollapse: 1
+--- !u!4 &2380776408053245292 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8346230885965490542, guid: 515b8fbccb9274059a250a572e4178bb,
+    type: 3}
+  m_PrefabInstance: {fileID: 5970070246805539842}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6634929535994531636
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/PukingPredator/Assets/Scripts/Puking.cs
+++ b/PukingPredator/Assets/Scripts/Puking.cs
@@ -29,11 +29,6 @@ public class Puking : InputBehaviour
     private const float PUKE_EXPLODE_THRESH = 0.8f;
 
     /// <summary>
-    /// If you have this many items in the inventory and you puke with force, you will knock back items in front of you
-    /// </summary>
-    private const int KNOCKBACK_ITEM_THRESH = 5;
-
-    /// <summary>
     /// Force applied to object when puked. Depends on how long the puke button
     /// was held down for.
     /// </summary>
@@ -87,7 +82,7 @@ public class Puking : InputBehaviour
             itemRb.AddForce(pukeVelocity * itemRb.mass, ForceMode.Impulse);
 
             // -1 because player loses an item when they puke
-            if (pukeForce > MAX_PUKE_FORCE * PUKE_EXPLODE_THRESH && inventory.itemCount >= KNOCKBACK_ITEM_THRESH - 1)
+            if (pukeForce > MAX_PUKE_FORCE * PUKE_EXPLODE_THRESH)
             {
                 KnockbackItemsInFrontofPlayer(pukeVelocity * pukeForce, pukeForce, itemRb);
             }

--- a/PukingPredator/Assets/Scripts/Puking.cs
+++ b/PukingPredator/Assets/Scripts/Puking.cs
@@ -97,7 +97,7 @@ public class Puking : InputBehaviour
     /// <param name="itemRB">RigidBody of item being puked</param>
     public void KnockbackItemsInFrontofPlayer(float pukeForce, Rigidbody itemRB)
     {
-        Debug.Log(pukeForce / MAX_PUKE_FORCE);
+        Debug.Log( pukeForce / MAX_PUKE_FORCE);
         Vector3 halfExtents = new Vector3(pukeForce / MAX_PUKE_FORCE, 0.5f, 0.5f); // Half the size of the box (x, y, z)
 
         // BoxCast in the direction of the velocity
@@ -119,9 +119,8 @@ public class Puking : InputBehaviour
             if (pb != null)
             {
                 pb.EnablePhysics();
-                hitRB.AddExplosionForce(1f * pukeForce, transform.position, 5f, 0.01f, ForceMode.VelocityChange);
-                //hitRB.AddForce(vec * hitRB.mass * 0.5f, ForceMode.Impulse); // alternate force if you want to push things forward
             }
+            hitRB.AddExplosionForce(1f * pukeForce, transform.position, 5f, 0.01f, ForceMode.VelocityChange);
         }
     }
 

--- a/PukingPredator/Assets/Scripts/Puking.cs
+++ b/PukingPredator/Assets/Scripts/Puking.cs
@@ -24,6 +24,16 @@ public class Puking : InputBehaviour
     private Vector3 pukeDirection => transform.forward + Vector3.up * 0.1f;
 
     /// <summary>
+    /// If pukeForce is greater than this, the puke will also knock back items in front of the player
+    /// </summary>
+    private const float PUKE_EXPLODE_THRESH = 0.8f;
+
+    /// <summary>
+    /// If you have this many items in the inventory and you puke with force, you will knock back items in front of you
+    /// </summary>
+    private const int KNOCKBACK_ITEM_THRESH = 5;
+
+    /// <summary>
     /// Force applied to object when puked. Depends on how long the puke button
     /// was held down for.
     /// </summary>
@@ -75,8 +85,38 @@ public class Puking : InputBehaviour
             //...the velocity and if there was a rigid body then we can reduce the velocity
             //...while calculating it based on the mass?
             itemRb.AddForce(pukeVelocity * itemRb.mass, ForceMode.Impulse);
+
+            // -1 because player loses an item when they puke
+            if (pukeForce > MAX_PUKE_FORCE * PUKE_EXPLODE_THRESH && inventory.itemCount >= KNOCKBACK_ITEM_THRESH - 1)
+            {
+                KnockbackItemsInFrontofPlayer(pukeVelocity * pukeForce, pukeForce, itemRb);
+            }
         }
 
+    }
+
+    public void KnockbackItemsInFrontofPlayer(Vector3 vec, float f, Rigidbody itemRB)
+    {
+
+        Vector3 halfExtents = new Vector3(1f, 0.5f, 0.5f); // Half the size of the box (x, y, z)
+
+        // BoxCast in the direction of the velocity
+        RaycastHit[] hits = Physics.BoxCastAll(transform.position + (transform.forward * 0.1f) + (transform.up * 0.6f), halfExtents, vec, Quaternion.identity, 3f);
+
+        foreach (RaycastHit hit in hits)
+        {
+            if (!hit.collider.CompareTag(GameTag.player))
+            {
+                Rigidbody hitRB = hit.collider.GetComponent<Rigidbody>();
+                PhysicsBehaviour pb = hit.collider.GetComponent<PhysicsBehaviour>();
+                if (hitRB != null && pb != null && hitRB != itemRB)
+                {
+                    pb.EnablePhysics();
+                    hitRB.AddExplosionForce(1f * f, transform.position, 5f, 0.01f, ForceMode.VelocityChange);
+                    //hitRB.AddForce(vec * hitRB.mass * 0.5f, ForceMode.Impulse); // alternate force if you want to push things forward
+                }
+            }
+        }
     }
 
 }


### PR DESCRIPTION
UPDATED WITH EFFECTS OF PUKE VISUALIZER CHANGE
Player must have
- at least 5 items in inventory
- puke with >80% force

if will knock back items in front of the player
- rectangle for knockback is large so the affect appears to go through walls
- applies an explosionforce at the player's location

TODOs for polish:
- show in inventoryUI when we go past this threshold
- show in charge bar when we go past this threshold, maybe turn the bar red
- some SFX