### PR TITLE
Collapse outline

### DIFF
--- a/PukingPredator/Assets/QuickOutline/Scripts/Outline.cs
+++ b/PukingPredator/Assets/QuickOutline/Scripts/Outline.cs
@@ -138,6 +138,7 @@ public class Outline : MonoBehaviour {
   }
 
   void OnDisable() {
+    UpdateMaterialProperties();
     foreach (var renderer in renderers) {
 
       // Remove outline shaders

--- a/PukingPredator/Assets/QuickOutline/Scripts/Outline.cs
+++ b/PukingPredator/Assets/QuickOutline/Scripts/Outline.cs
@@ -36,7 +36,7 @@ public class Outline : MonoBehaviour {
     get { return outlineColor; }
     set {
       outlineColor = value;
-      needsUpdate = true;
+      UpdateMaterialProperties();
     }
   }
 
@@ -138,7 +138,6 @@ public class Outline : MonoBehaviour {
   }
 
   void OnDisable() {
-    UpdateMaterialProperties();
     foreach (var renderer in renderers) {
 
       // Remove outline shaders

--- a/PukingPredator/Assets/Scripts/Interactable.cs
+++ b/PukingPredator/Assets/Scripts/Interactable.cs
@@ -16,7 +16,7 @@ public abstract class Interactable : MonoBehaviour
     /// <summary>
     /// Size of the outline visual.
     /// </summary>
-    private const float OUTLINE_RADIUS = 2.2f;
+    private const float OUTLINE_RADIUS = 3f;
 
     /// <summary>
     /// Settings for the outline of the consumable (toggled on via enable when player is near)

--- a/PukingPredator/Assets/Scripts/Interactable.cs
+++ b/PukingPredator/Assets/Scripts/Interactable.cs
@@ -58,5 +58,11 @@ public abstract class Interactable : MonoBehaviour
         outline.OutlineColor = outlineColor;
         outline.enabled = false;
     }
+
+    public void ChangeColor(Color color)
+    {
+        outline = gameObject.GetComponent<Outline>();
+        outline.OutlineColor = color;
+    }
 }
 

--- a/PukingPredator/Assets/Scripts/InteractablePicker.cs
+++ b/PukingPredator/Assets/Scripts/InteractablePicker.cs
@@ -55,17 +55,14 @@ public class InteractablePicker : MonoBehaviour
             targetInteractable = null;
         }
 
-        if (!targetInteractable || previousTargetInteractable != targetInteractable)
+        foreach (Interactable target in targetSupports)
         {
-            foreach (Interactable target in targetSupports)
-            {
-                target.ChangeColor(Color.white);
-                setOutline(target, false);
-                targetSupports = new List<Interactable>();
-            }
+            target.ChangeColor(Color.white);
+            setOutline(target, false);
         }
-        
 
+
+        targetSupports = new List<Interactable>();
         if (previousTargetInteractable != null)
         {
             setOutline(previousTargetInteractable, false);
@@ -168,7 +165,7 @@ public class InteractablePicker : MonoBehaviour
             }
         }
 
-        // Hihglights objects in the same physics collapse group
+        // Highlights objects in the same physics collapse group
         Transform parentTransform = interactable.transform.parent;
         PhysicsCollapseGroup physicsCollapseGroup = parentTransform.GetComponent<PhysicsCollapseGroup>();
 

--- a/PukingPredator/Assets/Scripts/InteractablePicker.cs
+++ b/PukingPredator/Assets/Scripts/InteractablePicker.cs
@@ -141,7 +141,9 @@ public class InteractablePicker : MonoBehaviour
     private void setOutline(Interactable interactable, bool enabled)
     {
         if (interactable.outline.enabled == enabled) return;
+
         interactable.outline.enabled = enabled;
+
         PhysicsSupport support = interactable.GetComponent<PhysicsSupport>();
         if (support != null)
         {
@@ -151,6 +153,22 @@ public class InteractablePicker : MonoBehaviour
                 Interactable supportInteractable = other.GetComponent<Interactable>();
                 targetSupports.Add(supportInteractable);
                 setOutline(supportInteractable, enabled);
+            }
+        }
+
+        Transform parentTransform = interactable.transform.parent;
+        PhysicsCollapseGroup physicsCollapseGroup = parentTransform.GetComponent<PhysicsCollapseGroup>();
+
+        if (physicsCollapseGroup != null)
+        {
+            foreach (Transform child in parentTransform)
+            {
+                Interactable supportInteractable = child.GetComponent<Interactable>();
+                if (supportInteractable != null)
+                {
+                    targetSupports.Add(supportInteractable);
+                    setOutline(supportInteractable, enabled);
+                }
             }
         }
     }

--- a/PukingPredator/Assets/Scripts/InteractablePicker.cs
+++ b/PukingPredator/Assets/Scripts/InteractablePicker.cs
@@ -60,11 +60,12 @@ public class InteractablePicker : MonoBehaviour
             target.outline.enabled = false;
         }
 
-        targetSupports = new List<Interactable>();
         if (previousTargetInteractable != null)
         {
             setOutline(previousTargetInteractable, false);
         }
+
+        targetSupports = new List<Interactable>();
         if (targetInteractable != null)
         {
             setOutline(targetInteractable, true);
@@ -143,19 +144,26 @@ public class InteractablePicker : MonoBehaviour
         if (interactable.outline.enabled == enabled) return;
 
         interactable.outline.enabled = enabled;
-
+        Color supportColor = enabled ? Color.red : Color.white;
+        // Enables group highlight for supported objects
         PhysicsSupport support = interactable.GetComponent<PhysicsSupport>();
         if (support != null)
         {
             if (support.supportsBeforeCollapse != 1) return;
+
             foreach (var other in support.initiallySupporting)
             {
+                // Ensures fallen walls are not highlihgted if the base is highlighted
+                if (other.GetComponent<PhysicsSupport>().supportsBeforeCollapse != 1) continue;
                 Interactable supportInteractable = other.GetComponent<Interactable>();
+                
+                supportInteractable.ChangeColor(supportColor);
                 targetSupports.Add(supportInteractable);
                 setOutline(supportInteractable, enabled);
             }
         }
 
+        // Hihglights objects in the same physics collapse group
         Transform parentTransform = interactable.transform.parent;
         PhysicsCollapseGroup physicsCollapseGroup = parentTransform.GetComponent<PhysicsCollapseGroup>();
 
@@ -163,9 +171,11 @@ public class InteractablePicker : MonoBehaviour
         {
             foreach (Transform child in parentTransform)
             {
+                if (child == interactable.transform) continue;
                 Interactable supportInteractable = child.GetComponent<Interactable>();
                 if (supportInteractable != null)
                 {
+                    supportInteractable.ChangeColor(supportColor);
                     targetSupports.Add(supportInteractable);
                     setOutline(supportInteractable, enabled);
                 }

--- a/PukingPredator/Assets/Scripts/InteractablePicker.cs
+++ b/PukingPredator/Assets/Scripts/InteractablePicker.cs
@@ -45,7 +45,7 @@ public class InteractablePicker : MonoBehaviour
     }
 
     private void Update()
-	{
+    {
         var previousTargetInteractable = targetInteractable;
         targetInteractable = GetViewedInteractable();
 
@@ -55,17 +55,22 @@ public class InteractablePicker : MonoBehaviour
             targetInteractable = null;
         }
 
-        foreach (Interactable target in targetSupports)
+        if (!targetInteractable || previousTargetInteractable != targetInteractable)
         {
-            target.outline.enabled = false;
+            foreach (Interactable target in targetSupports)
+            {
+                target.ChangeColor(Color.white);
+                setOutline(target, false);
+                targetSupports = new List<Interactable>();
+            }
         }
+        
 
         if (previousTargetInteractable != null)
         {
             setOutline(previousTargetInteractable, false);
         }
 
-        targetSupports = new List<Interactable>();
         if (targetInteractable != null)
         {
             setOutline(targetInteractable, true);
@@ -156,10 +161,10 @@ public class InteractablePicker : MonoBehaviour
                 // Ensures fallen walls are not highlihgted if the base is highlighted
                 if (other.GetComponent<PhysicsSupport>().supportsBeforeCollapse != 1) continue;
                 Interactable supportInteractable = other.GetComponent<Interactable>();
-                
-                supportInteractable.ChangeColor(supportColor);
-                targetSupports.Add(supportInteractable);
+
                 setOutline(supportInteractable, enabled);
+                supportInteractable.ChangeColor(supportColor);
+                if (enabled) targetSupports.Add(supportInteractable);
             }
         }
 
@@ -175,12 +180,11 @@ public class InteractablePicker : MonoBehaviour
                 Interactable supportInteractable = child.GetComponent<Interactable>();
                 if (supportInteractable != null)
                 {
+                    supportInteractable.outline.enabled = enabled;
                     supportInteractable.ChangeColor(supportColor);
-                    targetSupports.Add(supportInteractable);
-                    setOutline(supportInteractable, enabled);
+                    if (enabled) targetSupports.Add(supportInteractable);
                 }
             }
         }
     }
 }
-

--- a/PukingPredator/Assets/Scripts/Physics/PhysicsSupport.cs
+++ b/PukingPredator/Assets/Scripts/Physics/PhysicsSupport.cs
@@ -21,7 +21,7 @@ public class PhysicsSupport : MonoBehaviour
     /// List used purely to assign links in the level editor.
     /// </summary>
     [SerializeField]
-    private List<GameObject> initiallySupporting = new();
+    public List<GameObject> initiallySupporting = new();
 
     private PhysicsBehaviour physicsObject;
 
@@ -39,7 +39,7 @@ public class PhysicsSupport : MonoBehaviour
     /// If this many supports fail, the structure will collapse
     /// </summary>
     [SerializeField]
-    private int supportsBeforeCollapse = 1;
+    public int supportsBeforeCollapse { get; private set; } = 1;
 
 
 


### PR DESCRIPTION
Callopse outline shows the other objects that will collapse if you eat the highlighted object. It highlights teh supported objects in red.
![image](https://github.com/user-attachments/assets/c4dc281f-f6ab-48ba-afbb-c38f523e981e)
