### PR TITLE
Puke tweaks

### DIFF
--- a/PukingPredator/Assets/Prefabs/Player.prefab
+++ b/PukingPredator/Assets/Prefabs/Player.prefab
@@ -697,7 +697,7 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 641
   puking: {fileID: 4715212586831017785}
-  yCutoff: 0
+  yCutoff: -5
 --- !u!1001 &49880248143171028
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/PukingPredator/Assets/Scripts/Consumable/Consumable.cs
+++ b/PukingPredator/Assets/Scripts/Consumable/Consumable.cs
@@ -192,10 +192,8 @@ public class Consumable : Interactable
         }
 
         stateEvents[ItemState.inWorld].onEnter += ResetLayer;
-        stateEvents[ItemState.inWorld].onEnter += SetGravityEnabled;
         stateEvents[ItemState.inWorld].onEnter += ResetScale;
         stateEvents[ItemState.inWorld].onExit += SetLayerToConsumed;
-        stateEvents[ItemState.inWorld].onExit += SetGravityDisabled; 
         
         stateEvents[ItemState.beingConsumed].onEnter += EnablePhysics;
 
@@ -203,6 +201,8 @@ public class Consumable : Interactable
 
         stateEvents[ItemState.inInventory].onEnter += ClampShrunkScale;
         stateEvents[ItemState.inInventory].onEnter += StartDecay;
+        stateEvents[ItemState.inInventory].onEnter += SetGravityDisabled;
+        stateEvents[ItemState.inInventory].onExit += SetGravityEnabled;
         stateEvents[ItemState.inInventory].onUpdate += FollowInventory;
 
         if (rb != null) { stateEvents[ItemState.beingPuked].onEnter += ResetVelocity; }

--- a/PukingPredator/Assets/Scripts/Consumable/Consumable.cs
+++ b/PukingPredator/Assets/Scripts/Consumable/Consumable.cs
@@ -46,6 +46,11 @@ public class Consumable : Interactable
     public Timer decayTimer { get; private set; }
 
     /// <summary>
+    /// If the origin has been centered already or not.
+    /// </summary>
+    private bool hasOriginBeenCentered = false;
+
+    /// <summary>
     /// The layer that the object started out on.
     /// </summary>
     private int initialLayer;
@@ -194,7 +199,8 @@ public class Consumable : Interactable
         stateEvents[ItemState.inWorld].onEnter += ResetLayer;
         stateEvents[ItemState.inWorld].onEnter += ResetScale;
         stateEvents[ItemState.inWorld].onExit += SetLayerToConsumed;
-        
+        stateEvents[ItemState.inWorld].onExit += CenterOrigin;
+
         stateEvents[ItemState.beingConsumed].onEnter += EnablePhysics;
 
         stateEvents[ItemState.beingConsumed].onUpdate += UpdateBeingConsumed;
@@ -216,6 +222,14 @@ public class Consumable : Interactable
     }
 
 
+
+    private void CenterOrigin()
+    {
+        if (hasOriginBeenCentered) { return; }
+        hasOriginBeenCentered = true;
+
+        gameObject.CenterOrigin();
+    }
 
     private void ClampShrunkScale()
     {

--- a/PukingPredator/Assets/Scripts/Controls/GameInput.cs
+++ b/PukingPredator/Assets/Scripts/Controls/GameInput.cs
@@ -97,7 +97,7 @@ public class GameInput : SingletonMonobehaviour<GameInput>
     /// The amount of time that the puke button has been held. Only meaningful
     /// at the time that the puke event is triggered.
     /// </summary>
-    public float pukeHoldDuration => Mathf.Max(minHoldTime, Time.time - pukePressTime);
+    public float pukeHoldDuration => Mathf.Max(0, Time.time - pukePressTime - minHoldTime);
 
 
 

--- a/PukingPredator/Assets/Scripts/GameObjectExtensions.cs
+++ b/PukingPredator/Assets/Scripts/GameObjectExtensions.cs
@@ -4,6 +4,84 @@ using UnityEngine;
 public static class GameObjectExtensions
 {
     /// <summary>
+    /// Centeres the origin/pivot of the object by shifting the colliders,
+    /// visuals, and children. This may not work for objects with arbitrary
+    /// components attached, use with caution.
+    /// </summary>
+    /// <param name="gameObject"></param>
+    public static void CenterOrigin(this GameObject gameObject)
+    {
+        Collider[] colliders = gameObject.GetComponentsInChildren<Collider>();
+
+        if (colliders.Length == 0) { return; }
+
+        // Calculate the average center of all colliders
+        Vector3 center = Vector3.zero;
+        foreach (var col in colliders)
+        {
+            center += col.bounds.center;
+        }
+        center /= colliders.Length;
+
+        // Convert world position to local position
+        Vector3 localCenter = gameObject.transform.InverseTransformPoint(center);
+
+        // Shift all children and components to compensate for pivot change
+        foreach (Transform child in gameObject.transform)
+        {
+            child.localPosition -= localCenter;
+        }
+
+        // Offset the mesh vertices
+        MeshFilter meshFilter = gameObject.GetComponent<MeshFilter>();
+        if (meshFilter && meshFilter.sharedMesh)
+        {
+            meshFilter.sharedMesh = OffsetMesh(meshFilter.sharedMesh, -localCenter);
+        }
+
+        foreach (Collider col in colliders)
+        {
+            if (col is BoxCollider box)
+            {
+                box.center -= localCenter;
+            }
+            else if (col is SphereCollider sphere)
+            {
+                sphere.center -= localCenter;
+            }
+            else if (col is CapsuleCollider capsule)
+            {
+                capsule.center -= localCenter;
+            }
+        }
+
+        // Adjust object position to maintain visual placement
+        gameObject.transform.position += gameObject.transform.TransformVector(localCenter);
+    }
+    /// <summary>
+    /// Helper for CenterOrigin.
+    /// </summary>
+    /// <param name="original"></param>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    private static Mesh OffsetMesh(Mesh original, Vector3 offset)
+    {
+        if (!original) return null;
+
+        Mesh newMesh = GameObject.Instantiate(original);
+        Vector3[] vertices = newMesh.vertices;
+
+        for (int i = 0; i < vertices.Length; i++)
+        {
+            vertices[i] += offset;
+        }
+
+        newMesh.vertices = vertices;
+        newMesh.RecalculateBounds();
+        return newMesh;
+    }
+
+    /// <summary>
     /// 
     /// </summary>
     /// <param name="gameObject"></param>

--- a/PukingPredator/Assets/Scripts/ProjectileBlast.cs
+++ b/PukingPredator/Assets/Scripts/ProjectileBlast.cs
@@ -23,7 +23,7 @@ public class ProjectileBlast : MonoBehaviour
     void Start()
 	{
         ownerCollisionDetector = owner.AddComponent<CollisionDetector>();
-        ownerCollisionDetector.Subscribe(Explode);
+        ownerCollisionDetector.Subscribe(TryExplode);
 
     }
 
@@ -49,6 +49,11 @@ public class ProjectileBlast : MonoBehaviour
 
             hitRB.AddExplosionForce(blastForce, transform.position, 5f, 0.01f, ForceMode.VelocityChange);
         }
+    }
+    private void TryExplode()
+    {
+        var rb = owner.GetComponent<Rigidbody>();
+        if (rb.velocity.HorizontalProjection().magnitude > 1.5f) { Explode(); }
 
         //destroy self, only do one blast collision
         Destroy(gameObject);

--- a/PukingPredator/Assets/Scripts/PukeTrajectory.cs
+++ b/PukingPredator/Assets/Scripts/PukeTrajectory.cs
@@ -82,8 +82,6 @@ public class PukeTrajectory : InputBehaviour
         Vector3 currentPosition = transform.position;
         float initialHeight = currentPosition.y;
         Vector3 velocity = puking.pukeVelocity;
-        // the scale of the object at any given time
-        var scale = Consumable.consumptionCutoff;
 
         int pointIndex = 0;
         for (int i = 0; i < maxPoints; i++)
@@ -109,14 +107,7 @@ public class PukeTrajectory : InputBehaviour
 
             // Update position and velocity for the next point based on physics
             currentPosition += velocity * timeStep;
-            velocity += Physics.gravity * timeStep * scale; // Apply gravity to the velocity
-
-            // Scale the velocity
-            if (scale >= 1) { continue; }
-            //var prevScale = scale;
-            scale = Mathf.Lerp(scale, 1.05f, Consumable.pukeRate * timeStep);
-            scale = Mathf.Min(scale, 1);
-            //velocity *= scale / prevScale;
+            velocity += Physics.gravity * timeStep; // Apply gravity to the velocity
         }
 
         // Assign the calculated points to the LineRenderer to display the trajectory

--- a/PukingPredator/Assets/Scripts/Puking.cs
+++ b/PukingPredator/Assets/Scripts/Puking.cs
@@ -112,11 +112,11 @@ public class Puking : InputBehaviour
             //itemRb.AddForce(pukeVelocity * itemRb.mass, ForceMode.Impulse);
             itemRb.velocity = pukeVelocity;
 
-            if (pukeWithForce)
-            {
-                KnockbackItemsInFrontofPlayer(pukeForce, itemRb);
-                AddCollisionBlast(itemToPuke.gameObject, itemRb);
-            }
+            //if (pukeWithForce)
+            //{
+            //    KnockbackItemsInFrontofPlayer(pukeForce, itemRb);
+            //    AddCollisionBlast(itemToPuke.gameObject, itemRb);
+            //}
         }
 
     }

--- a/PukingPredator/Assets/Scripts/Puking.cs
+++ b/PukingPredator/Assets/Scripts/Puking.cs
@@ -28,7 +28,8 @@ public class Puking : InputBehaviour
     /// <summary>
     /// The direction to puke in. Pukes forwards with a little force upwards.
     /// </summary>
-    private Vector3 pukeDirection => transform.forward + Vector3.up * 0.1f;
+    private Vector3 pukeDirection => transform.forward + Vector3.up * PUKE_VERTICAL_FACTOR;
+    private const float PUKE_VERTICAL_FACTOR = 0.5f;
 
     /// <summary>
     /// The collision tracker used to roughly determine the objects that could
@@ -57,13 +58,17 @@ public class Puking : InputBehaviour
         get
         {
             float holdPercent = gameInput.pukeHoldDuration / MAX_PUKE_DURATION;
-            holdPercent = Mathf.Pow(holdPercent, 2);
+            holdPercent = Mathf.Pow(holdPercent, 2); //spend more time on lower charges
             holdPercent = Mathf.Clamp(holdPercent, 0, 1);
-            return Mathf.Lerp(MIN_PUKE_FORCE * player.relativeScale, MAX_PUKE_FORCE, holdPercent);
+            return Mathf.Lerp(
+                MIN_PUKE_FORCE * Mathf.Pow(player.relativeScale, 0.25f),
+                MAX_PUKE_FORCE * Mathf.Pow(player.relativeScale, 0.35f),
+                holdPercent
+            );
         }
     }
-    private const float MIN_PUKE_FORCE = 1f;
-    private const float MAX_PUKE_FORCE = 20f;
+    private const float MIN_PUKE_FORCE = 2f;
+    private const float MAX_PUKE_FORCE = 10f;
     private const float MAX_PUKE_DURATION = 2f;
 
     /// <summary>
@@ -104,7 +109,8 @@ public class Puking : InputBehaviour
             //TODO: make this code work if there is no rigid body. perhaps just set
             //...the velocity and if there was a rigid body then we can reduce the velocity
             //...while calculating it based on the mass?
-            itemRb.AddForce(pukeVelocity * itemRb.mass, ForceMode.Impulse);
+            //itemRb.AddForce(pukeVelocity * itemRb.mass, ForceMode.Impulse);
+            itemRb.velocity = pukeVelocity;
 
             if (pukeWithForce)
             {


### PR DESCRIPTION
The previous puke changes to make aiming easier and to disable the explosive puking behaviour (stuff nearby you getting knocked back, stuff that you hit getting knocked down). The explosive puke stuff can still be added back in at a later point by uncommenting the few lines i commented out in the Puking.cs script, but at least for now we dont really utilize the mechanic and dont tutorialize it well.